### PR TITLE
:arrow_up: 默认安装rpc包，以保障Demo正常运行

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,7 @@
     ],
     "require": {
         "easyswoole/easyswoole": "3.x-dev",
-        "easyswoole/rpc": "^1.0",
-        "easyswoole/mysqli": "^1.0"
+        "easyswoole/rpc": "dev-master"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
默认demo中并没有在composer中安装rpc服务，如直接运行会导致无法找到Rpc相关组件而报错