### PR TITLE
修复报错

### DIFF
--- a/App/HttpController/BaseController.php
+++ b/App/HttpController/BaseController.php
@@ -5,7 +5,7 @@ namespace App\HttpController;
 
 
 use EasySwoole\EasySwoole\ServerManager;
-use EasySwoole\Http\AbstractInterface\AnnotationController;
+use EasySwoole\HttpAnnotation\AnnotationController;
 
 class BaseController extends AnnotationController
 {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "require": {
     "easyswoole/easyswoole": "3.x",
+    "easyswoole/http-annotation": "dev-master",
     "easyswoole/orm": "dev-master"
   },
   "autoload": {


### PR DESCRIPTION
访问示例URL时，报错：
Class 'EasySwoole\Http\AbstractInterface\AnnotationController' not found

经查，EasySwoole\Http\AbstractInterface\目录下，没有AnnotationController文件;

引入"easyswoole/http-annotation"
使用EasySwoole\HttpAnnotation\AnnotationController 
替换EasySwoole\Http\AbstractInterface\AnnotationController;